### PR TITLE
Update parity version to latest stable version

### DIFF
--- a/bootnode.yml
+++ b/bootnode.yml
@@ -1,7 +1,7 @@
-version: '3'
+version: "3"
 services:
   bootnode:
-    image: parity/parity:v2.5.13-stable
+    image: parity/parity:v2.7.2-stable
     container_name: bootnode
     volumes:
       - ./bootnode:/home/parity/.local/share/io.parity.ethereum


### PR DESCRIPTION
Stable tag is found here: https://hub.docker.com/r/parity/parity/tags